### PR TITLE
Add links to GitClear stat widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 ## Statistical Tools (Widgets)
 
+- [GitClear Commit Activity Bubble Graph](https://www.gitclear.com/github_profile_dynamic_readme_free#commit_activity) - Dynamically generating daily visualization of which tickets/repos/branches are being worked on by individual or team
+- [GitClear Area Charts for GitHub Profiles](https://www.gitclear.com/github_profile_dynamic_readme_free#area_graph) - Dynamically generating area charts to showcase relative velocity of work across repos
 - [GitHub Contributions Chart](https://github.com/sallar/github-contributions-chart#readme) - :octocat: Generate an image of all your Github contributions
 - [GitHub Readme LinkedIn](https://github.com/soroushchehresa/github-readme-linkedin#readme) - 📋 Dynamically generated images from your LinkedIn profile on your github readmes.
 - [GitHub Readme Medium](https://github.com/omidnikrah/github-readme-medium#readme) - 📖 Dynamically generated your latest Medium article on your github readmes.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 ## Statistical Tools (Widgets)
 
-- [GitClear Commit Activity Bubble Graph](https://www.gitclear.com/github_profile_dynamic_readme_free#commit_activity) - Dynamically generating daily visualization of which tickets/repos/branches are being worked on by individual or team
-- [GitClear Area Charts for GitHub Profiles](https://www.gitclear.com/github_profile_dynamic_readme_free#area_graph) - Dynamically generating area charts to showcase relative velocity of work across repos
+- [GitClear Commit Activity](https://www.gitclear.com/github_profile_dynamic_readme_free#commit_activity) - Dynamically generating daily visualization of which tickets/repos/branches are being worked on by individual or team
+- [GitClear Area Charts](https://www.gitclear.com/github_profile_dynamic_readme_free#area_graph) - Dynamically generating area charts to showcase relative velocity of work across repos
 - [GitHub Contributions Chart](https://github.com/sallar/github-contributions-chart#readme) - :octocat: Generate an image of all your Github contributions
 - [GitHub Readme LinkedIn](https://github.com/soroushchehresa/github-readme-linkedin#readme) - 📋 Dynamically generated images from your LinkedIn profile on your github readmes.
 - [GitHub Readme Medium](https://github.com/omidnikrah/github-readme-medium#readme) - 📖 Dynamically generated your latest Medium article on your github readmes.


### PR DESCRIPTION
GitClear recently added a page that describes the free GitHub profile stat widgets users can generate. 

[There are actually quite a few other widget visualizations that GitClear can generate](https://asset.gitclear.com/assets/pages/github_profile_splash/config-options-04b73498adda72f097e0321a29b27bdbfd62fdc423af0df88cac4e875c786e63.png), but I left this PR w/ just two types of widgets GitClear offers so hopefully it still feels balanced among various GH profile widget providers 

Happy to amend in any way upon request. Lmk if you think labeling these widgets as "free" matters, since it might not be obvious from the text itself.