### PR TITLE
Add terminal-identity to Statistical Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [Isometric Contributions](https://github.com/Spectrewolf8/isometric-contributions) - Generate beautiful 3D isometric visualizations of GitHub contribution graphs with customizable themes, live preview builder, dark mode support, and intelligent caching.
 - [Profile Activity Generator](https://github.com/omidnikrah/profile-activity-generator#readme) - Generate custom profile activity for your profile readme.
 - [Readme Pagespeed Insights](https://github.com/ankurparihar/readme-pagespeed-insights#readme) - Google lighthouse stats of your website that you can put in readme.
+- [Terminal Identity](https://github.com/doyoon530/terminal-identity#readme) - 🖥️ Generate terminal-style SVG identity cards for your github profile readme with live stats, 4 provider shells, 8 themes, and zero config.
 - [Waka Readme](https://github.com/athul/waka-readme#readme) - Wakatime weekly metrics on your profile readme.
 - [YouTube Stats Card](https://github.com/Dhyeythumar/youtube-stats-card#readme) - 🚀 Dynamic YouTube stats card for your github readmes.
 


### PR DESCRIPTION
<img width="851" height="615" alt="스크린샷 2026-04-11 오후 12 45 42" src="https://github.com/user-attachments/assets/18e9e2e7-311a-4883-86fb-c337e36657ba" />

## Description

Adds [terminal-identity](https://github.com/doyoon530/terminal-identity) to the **Statistical Tools (Widgets)** section.

Terminal Identity is a highly customizable GitHub README card generator for creating terminal-style SVG profile cards with live GitHub stats, top languages, multiple shell styles, and rich theme customization. It supports both bar-chart and skill-icon language views and can be embedded with a single image URL.

- Live playground: https://terminal-identity-opal.vercel.app
- Hosted on Vercel and served as `image/svg+xml`

## Checklist

- [x] Added to the correct section (Statistical Tools)
- [x] Alphabetical order maintained
- [x] Follows the format `[Name](link#readme) - Description.`
- [x] Link is correct and repository is public
- [x] No duplicate entry