### PR TITLE
Add NRG to Readme Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [rahuldkjain/GitHub Profile Readme Generator](https://github.com/rahuldkjain/github-profile-readme-generator#readme) - 🚀 Generate github profile readme easily with the latest add-ons like visitors count, github stats, etc using minimal UI.
 - [GitHub Profile Readme Maker](https://github.com/VishwaGauravIn/github-profile-readme-maker#readme) - 🏆 Best Profile Generator, Create your perfect GitHub Profile ReadMe in the best possible way. Lots of features and tools included, all for free ! 💫.
 - [GitHub Profilinator](https://github.com/rishavanand/github-profilinator#readme) - 🚀 This tool contains mini GUI components that you can hook together to automatically generate markdown code for a perfect readme.
+- [NRG](https://github.com/nanolaba/readme-generator#readme) - Multi-language README generator that builds README files from a single `.src.md` template with imports, widgets, and a table-of-contents engine. CLI, Maven plugin, and Java library.
 - [Plantek README Manager](https://gitlab.com/MarleyPlant/readme-manager) - Stop wasting time on READMEs. This CLI tool generates professional documents for your Git projects with ease.
 - [Profile Readme Generator](https://github.com/maurodesouza/profile-readme-generator#readme) - 🎨 Beautify your github profile with this amazing tool.
 - [REHeader](https://github.com/khalby786/REHeader#readme) - Generate beautiful header images for your github profile readmes.


### PR DESCRIPTION
Adds NRG (Nanolaba Readme Generator) to the Readme Generator section.

NRG generates multi-language README files (e.g. `README.md` and `README.ru.md`) from a single `.src.md` template via imports, custom widgets, and a built-in TOC widget. Distributed as a CLI, Maven plugin, and Java library.

- Repo: https://github.com/nanolaba/readme-generator
- Maven Central: https://central.sonatype.com/artifact/com.nanolaba/readme-generator

Adheres to the contribution guidelines: alphabetized (between `GitHub Profilinator` and `Plantek README Manager`), capital start + period, `#readme` anchor, single suggestion per PR.