### PR TITLE
Add TinyTools OG Image Generator to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 - [Spotify Readme](https://github.com/tthn0/Spotify-Readme#readme) - A modern and customizable widget for showing your current Spotify song on your github profile.
 - [Simple Icons](https://github.com/simple-icons/simple-icons#readme) - SVG icons for popular brands.
 - [Spotify Recently Played Readme](https://github.com/JeffreyCA/spotify-recently-played-readme) - Display your recently played Spotify tracks on your GitHub profile README.
+- [TinyTools OG Image Generator](https://tinytools-smoky.vercel.app/) - Free, browser-based Open Graph image generator for repo social-preview cards (the image GitHub shows when a repo URL is shared on Twitter/Slack/etc). No signup; part of an open-source web utilities collection.
 
 ## Contribute
 


### PR DESCRIPTION
Hi! Thanks for maintaining this list 🙌

Adds [TinyTools OG Image Generator](https://tinytools-smoky.vercel.app/) to the Miscellaneous section. It'''s a free, browser-based generator for the Open Graph images that show up as the social-preview card when a GitHub repo URL is shared (Twitter/X, Slack, Discord, LinkedIn, etc.) — sits in the same neighborhood as the existing GitHub Profile Header Generator and Simple Icons entries.

No signup, no upload, MIT-licensed. Happy to adjust the placement or wording if you'''d prefer a different section or framing — feel free to close if it'''s not a good fit.

Thanks!