### PR TITLE
Add Three Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 - [My Most Famous Followers](https://github.com/Joe-Huber/my-most-followed-followers) - Automatically creates a table in your read me with your most followed followers.
 - [Profile Readme](https://github.com/actions-js/profile-readme#readme) - Display profile activity and other cool widgets in your profile readme.
 - [Profile Readme Stats](https://github.com/teoxoy/profile-readme-stats#readme) - Showcase your github stats on your profile readme.
+- [Three Readme](https://github.com/kpab/three-readme#readme) - Render genuine Three.js scenes as animated SVGs to embed in your readme.
 - [Waka Readme Stats](https://github.com/anmol098/waka-readme-stats#readme) - GitHub action helps to add cool dev metrics to your github profile readme.
 
 ## Badges


### PR DESCRIPTION
Adds **Three Readme** to the *GitHub Actions for Readmes* category, in alphabetical order (between *Profile Readme Stats* and *Waka Readme Stats*).

Three Readme renders genuine Three.js scenes into animated SVGs (SMIL) and commits them back into your repo for embedding in a README. Unlike static badge/stat tools, it bakes real 3D rendering into a self-contained SVG that animates on both light and dark GitHub themes — see the live gallery and demos in the repo.

- Format: `[Tool name](link) - Description.` with `#readme` link, capitalized start, period end.
- One suggestion in this PR; entry placed in alphabetical order.
- Formatted per `.editorconfig`.