### PR TITLE
Add GitHub Profile Stats to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [GitHub Contributions Chart](https://github.com/sallar/github-contributions-chart#readme) - :octocat: Generate an image of all your Github contributions
 - [Github Follow Tracker](https://github.com/Bittu5134/GH-Follow-Tracker) - 📈 Showcase Follower History using dynamically generating SVG images.
 - [GitHub PR Stats](https://github.com/f14XuanLv/github-pr-stats#readme) - 📊 Generate dynamic SVG tables showcasing your GitHub pull requests with repository statistics and star-based filtering.
+- [GitHub Profile Stats](https://github.com/rowkav09/GitHub-profile-stats) - Free, real-time GitHub stat cards, language charts, mini badges & activity sparklines for your github readme. No token, no setup - just paste one line.
 - [GitHub Readme LinkedIn](https://github.com/soroushchehresa/github-readme-linkedin#readme) - 📋 Dynamically generated images from your LinkedIn profile on your github readmes.
 - [GitHub Readme Medium](https://github.com/omidnikrah/github-readme-medium#readme) - 📖 Dynamically generated your latest Medium article on your github readmes.
 - [GitHub Readme Packagist Stats](https://github.com/agonyz/github-readme-packagist-stats) - Dynamically generated statistics of your Packagist Bundles for your GitHub readme.


### PR DESCRIPTION
Adds GitHub Profile Stats to the Statistical Tools (Widgets) section (placed alphabetically). It's a free, open-source (MIT) tool for real-time GitHub stat cards, language charts, mini badges, and activity sparklines — no personal access token or deployment needed, just paste one line. Repo: https://github.com/rowkav09/GitHub-profile-stats · Live demo: https://ghstats.dev