### PR TITLE
Add GitHub Readme Contribution Merger

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [GitHub Contributions Chart](https://github.com/sallar/github-contributions-chart#readme) - :octocat: Generate an image of all your Github contributions
 - [Github Follow Tracker](https://github.com/Bittu5134/GH-Follow-Tracker) - 📈 Showcase Follower History using dynamically generating SVG images.
 - [GitHub PR Stats](https://github.com/f14XuanLv/github-pr-stats#readme) - 📊 Generate dynamic SVG tables showcasing your GitHub pull requests with repository statistics and star-based filtering.
+- [GitHub Readme Contribution Merger](https://github.com/apoorvdarshan/github-readme-contribution-merger#readme) - Merge multiple GitHub users' contribution graphs into one customizable SVG heatmap.
 - [GitHub Readme LinkedIn](https://github.com/soroushchehresa/github-readme-linkedin#readme) - 📋 Dynamically generated images from your LinkedIn profile on your github readmes.
 - [GitHub Readme Medium](https://github.com/omidnikrah/github-readme-medium#readme) - 📖 Dynamically generated your latest Medium article on your github readmes.
 - [GitHub Readme Packagist Stats](https://github.com/agonyz/github-readme-packagist-stats) - Dynamically generated statistics of your Packagist Bundles for your GitHub readme.


### PR DESCRIPTION
## What changed

Added GitHub Readme Contribution Merger to the Statistical Tools (Widgets) section.

## Why

The tool combines contribution graphs from multiple GitHub users into one customizable SVG heatmap that can be embedded directly in a profile or project README.

## Validation

- Confirmed the entry is alphabetized.
- Confirmed the description follows the required format and ends with a period.
- Confirmed the linked repository is publicly accessible.
