### PR TITLE
Add Minimal GitHub Stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [GitHub Readme Telegram](https://github.com/Malith-Rukshan/telegram-card) - Showcase your Telegram presence with beautiful, dynamic preview cards.
 - [GitHub Readme Twitter](https://github.com/gazf/github-readme-twitter#readme) - Add Twitter to your github readmes.
 - [Isometric Contributions](https://github.com/Spectrewolf8/isometric-contributions) - Generate beautiful 3D isometric visualizations of GitHub contribution graphs with customizable themes, live preview builder, dark mode support, and intelligent caching.
+- [Minimal GitHub Stats](https://github.com/antonisloukis/minimal-github-stats) - Generate customizable, self-hosted GitHub profile statistics as an SVG using Python and GitHub Actions.
 - [Profile Activity Generator](https://github.com/omidnikrah/profile-activity-generator#readme) - Generate custom profile activity for your profile readme.
 - [Readme Pagespeed Insights](https://github.com/ankurparihar/readme-pagespeed-insights#readme) - Google lighthouse stats of your website that you can put in readme.
 - [Terminal Identity](https://github.com/doyoon530/terminal-identity#readme) - 🖥️ Generate terminal-style SVG identity cards for your github profile readme with live stats, 4 provider shells, 8 themes, and zero config.


### PR DESCRIPTION
## Summary

Adds Minimal GitHub Stats to the Statistical Tools (Widgets) section.

## Project

Minimal GitHub Stats generates customizable, self-hosted GitHub profile statistics as an SVG using Python and GitHub Actions.

Repository: https://github.com/antonisloukis/minimal-github-stats

## Checklist

- [x] Entry is alphabetized
- [x] Description is short and descriptive
- [x] Description starts with a capital letter
- [x] Description ends with a period
- [x] This pull request contains one suggestion
- [x] The project is not already listed