### PR TITLE
Add gh-stats to Statistical Tools (Widgets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 ## Statistical Tools (Widgets)
 
+- [gh-stats](https://gh-stats.com) - Single SVG card for your profile readme with a score out of 100, contribution timeline, top collaborators, languages, commit streaks, and tags derived from your repos.
 - [GitClear Commit Activity](https://www.gitclear.com/github_profile_dynamic_readme_free#commit_activity) - Dynamically generating daily visualization of which tickets/repos/branches are being worked on by individual or team
 - [GitClear Area Charts](https://www.gitclear.com/github_profile_dynamic_readme_free#area_graph) - Dynamically generating area charts to showcase relative velocity of work across repos
 - [GitHub Contributions Chart](https://github.com/sallar/github-contributions-chart#readme) - :octocat: Generate an image of all your Github contributions


### PR DESCRIPTION
Adds one entry to **Statistical Tools (Widgets)**:

```
- [gh-stats](https://gh-stats.com) - Single SVG card for your profile readme with a score out of 100, contribution timeline, top collaborators, languages, commit streaks, and tags derived from your repos.
```

**Disclosure:** I'm the author of this tool.

What it is: a hosted SVG card you embed with one line of markdown, `![stats](https://gh-stats.com/api/YOUR_USERNAME)`. No signup. It has 5 themes (midnight, onyx, nord, clean, paper) and auto-switches with GitHub's dark/light mode. Live example: https://gh-stats.com/api/ShayManor

Source is MIT licensed at https://github.com/ShayManor/github-readme-stats — happy to point the entry link at the repo instead of the site if you prefer that convention for this section.

Checklist against contributing.md:
- Alphabetized (sorts before `GitClear`, so it lands at the top of the section) — happy to move it if you'd rather place it elsewhere.
- Format `[Tool name](link) - Description.`, capital start, full stop.
- One suggestion in this PR, one file changed, one line added.
- Searched previous PRs; no existing entry or PR for this tool.
- Note this is unrelated to the existing [Ghstats](https://github.com/tiennm99/ghstats) entry under *GitHub Actions for Readmes*; that entry is untouched.
